### PR TITLE
Used cashed distances for better performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test_filtered_via:
 	./bin/main --test -index-type 'filtered' -load 'filtered_index.bin' -L 120 -k 100 -gt-file 'data/Dummy/dummy-groundtruth.bin' -query-file 'data/Dummy/dummy-queries.bin' -query 1
 
 test_stiched_via:
-	./bin/main --test -index-type 'stiched' -load 'stiched_index.bin' -L 120 -k 100 -gt-file 'data/Dummy/dummy-groundtruth.bin' -query-file 'data/Dummy/dummy-queries.bin' -query 1
+	./bin/main --test -index-type 'stiched' -load 'stiched_index.bin' -L 150 -k 100 -gt-file 'data/Dummy/dummy-groundtruth.bin' -query-file 'data/Dummy/dummy-queries.bin' -query 1
 
 
 run_tests:

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -198,7 +198,7 @@ void Create(std::unordered_map<std::string, std::string> args) {
         std::cerr << "Error opening file for writing." << std::endl;
         return;
       }
-      std::cout << std::endl << green << "Vamana Index was saved successfully to `" << brightYellow << outputFile << "`" << std::endl;
+      std::cout << std::endl << green << "Vamana Index was saved successfully to " << brightYellow << "`" << outputFile << "`" << reset << std::endl;
     }
   } else {
     BaseVectorVector base_vectors = ReadFilteredBaseVectorFile(baseFile);
@@ -215,6 +215,7 @@ void Create(std::unordered_map<std::string, std::string> args) {
 
       if (save) {
         index.saveGraph(outputFile);
+        std::cout << std::endl << green << "Vamana Index was saved successfully to " << brightYellow << "`" << outputFile << "`" << reset << std::endl;
       }
     } else if (indexType == "stiched") {
       StichedVamanaIndex<BaseDataVector<float>> index(filters);
@@ -222,7 +223,7 @@ void Create(std::unordered_map<std::string, std::string> args) {
 
       if (save) {
         index.saveGraph(outputFile);
-        std::cout << std::endl << green << "Vamana Index was saved successfully to `" << brightYellow << outputFile << "`" << std::endl;
+        std::cout << std::endl << green << "Vamana Index was saved successfully to " << brightYellow << "`" << outputFile << "`" << reset << std::endl;
       }
     }
   }
@@ -240,8 +241,8 @@ void TestSimple(std::unordered_map<std::string, std::string> args) {
   if (!getParameterValue(args, "-query-file", queryFile)) return;
   if (!getParameterValue(args, "-query", queryNumber)) return;
 
-  BaseVectors base_vectors = ReadVectorFile(queryFile);
-  if (base_vectors.empty()) {
+  BaseVectors query_vectors = ReadVectorFile(queryFile);
+  if (query_vectors.empty()) {
     std::cerr << "Error reading query file" << std::endl;
     return;
   }
@@ -259,7 +260,7 @@ void TestSimple(std::unordered_map<std::string, std::string> args) {
   GraphNode<DataVector<float>> s = vamanaIndex.findMedoid(vamanaIndex.getGraph(), 1000);
   
   auto start = std::chrono::high_resolution_clock::now();
-  SimpleGreedyResult greedyResult = GreedySearch(vamanaIndex.getGraph(), s, base_vectors.at(std::stoi(queryNumber)), std::stoi(k), std::stoi(L));
+  SimpleGreedyResult greedyResult = GreedySearch(vamanaIndex, s, query_vectors.at(std::stoi(queryNumber)), std::stoi(k), std::stoi(L), TEST);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = end - start;
 
@@ -322,7 +323,7 @@ void TestFilteredOrStiched(std::unordered_map<std::string, std::string> args) {
   }
 
   auto start = std::chrono::high_resolution_clock::now();
-  FilteredGreedyResult greedyResult = FilteredGreedySearch(index.getGraph(), start_nodes, xq, std::stoi(k), std::stoi(L), Fx);
+  FilteredGreedyResult greedyResult = FilteredGreedySearch(index, start_nodes, xq, std::stoi(k), std::stoi(L), Fx, TEST);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = end - start;
 

--- a/include/FilteredVamanaIndex.h
+++ b/include/FilteredVamanaIndex.h
@@ -2,10 +2,13 @@
 #define FILTERED_VAMANA_INDEX_H
 
 #include <iostream>
+#include <map>
 #include "VamanaIndex.h"
 #include "Filter.h"
 
 using Filter = CategoricalAttributeFilter;
+
+template <typename vamana_t> class VamanaIndex;
 
 template <typename vamana_t> class FilteredVamanaIndex : public VamanaIndex<vamana_t> {
 

--- a/include/GreedySearch.h
+++ b/include/GreedySearch.h
@@ -14,6 +14,22 @@
 #include "distance.h"
 #include <queue>
 #include <cmath>
+#include "VamanaIndex.h"
+#include "FilteredVamanaIndex.h"
+
+/**
+ * @brief Enum to define the execution mode of the algorithm.
+ * 
+ * The algorithm can be executed in two modes: CREATE and TEST. CREATE mode is used to create the index, 
+ * while TEST mode is used to test the index.
+ */
+enum EXEC_MODE {
+    CREATE = 0,
+    TEST = 1
+};
+
+template <typename vamana_t> class VamanaIndex;
+template <typename vamana_t> class FilteredVamanaIndex;
 
 /**
  * @brief Greedy search algorithm for finding the k nearest nodes in a graph relative to a query vector.
@@ -31,20 +47,22 @@
  * @return Pair of sets: the first set contains the k nearest nodes, and the second set contains all visited nodes
  */
 template <typename graph_t, typename query_t> std::pair<std::set<graph_t>, std::set<graph_t>> GreedySearch(
-    const Graph<graph_t>& G, 
+    const VamanaIndex<graph_t>& index, 
     const GraphNode<graph_t>& s, 
     const query_t& xq, 
     unsigned int k, 
-    unsigned int L
+    unsigned int L,
+    const EXEC_MODE execMode = CREATE
 );
 
 template <typename graph_t, typename query_t> std::pair<std::set<graph_t>, std::set<graph_t>> FilteredGreedySearch(
-    const Graph<graph_t>& G, 
+    const FilteredVamanaIndex<graph_t>& index, 
     const std::vector<GraphNode<graph_t>>& S, 
     const query_t& xq,  
     const unsigned int k, 
     const unsigned int L,  
-    const std::vector<CategoricalAttributeFilter>& queryFilters
+    const std::vector<CategoricalAttributeFilter>& queryFilters,
+    const EXEC_MODE execMode = CREATE
 );
                      
 

--- a/include/RobustPrune.h
+++ b/include/RobustPrune.h
@@ -2,6 +2,10 @@
 #include "graph.h"
 #include "DataVector.h"
 #include "BQDataVectors.h"
+#include "VamanaIndex.h"
+
+template <typename graph_t> class VamanaIndex;
+template <typename graph_t> class FilteredVamanaIndex;
 
 /**
  * @brief Prunes the neighbors of a given node in a graph based on a robust pruning algorithm.
@@ -24,7 +28,7 @@
  * 5. Stops when the number of neighbors of `p_node` reaches `R` or `V` is empty.
  */
 template <typename graph_t>
-void RobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R);
+void RobustPrune(VamanaIndex<graph_t>& index, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R);
 
 template <typename graph_t>
-void FilteredRobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node,std::set<graph_t>& V, float alpha,int R);
+void FilteredRobustPrune(FilteredVamanaIndex<graph_t>& index, GraphNode<graph_t>& p_node,std::set<graph_t>& V, float alpha,int R);

--- a/include/VamanaIndex.h
+++ b/include/VamanaIndex.h
@@ -30,6 +30,7 @@ protected:
   
   Graph<vamana_t> G;
   std::vector<vamana_t> P;
+  double** distanceMatrix;
 
   /**
    * @brief Fills the graph nodes with the given dataset points. 
@@ -43,6 +44,13 @@ protected:
    * @param maxEdges the maximum number of edges a node can have.
   */
   void createRandomEdges(const unsigned int maxEdges);
+
+  /**
+   * @brief Computes the distances between every node in the dataset and stores them in the distance matrix.
+   * 
+   * @param visualize a boolean flag to visualize the progress of the computation
+   */
+  void computeDistances(const bool visualize = true);
 
 public:
 
@@ -73,6 +81,13 @@ public:
   inline std::vector<GraphNode<vamana_t>> getNodes(void) const { return this->G.getNodesVector(); }
 
   /**
+   * @brief Returns the distance matrix of the Vamana Index entity as a double pointer.
+   * 
+   * @return the distance matrix
+   */
+  inline double** getDistanceMatrix(void) const { return this->distanceMatrix; }
+
+  /**
    * @brief Creates a Vamana Index Graph according to the provided dataset points and the given parameters.
    * Specifically this method follows the Vamana algorithm found on the paper:
    * 
@@ -87,7 +102,7 @@ public:
    * @param R the parameter R
    * 
   */
-  void createGraph(const std::vector<vamana_t>& P, const float& alpha, const unsigned int L, const unsigned int& R, bool visualize = true);
+  void createGraph(const std::vector<vamana_t>& P, const float& alpha, const unsigned int L, const unsigned int& R, bool visualize = true, double** distanceMatrix = nullptr);
 
   /**
    * @brief Saves a specific graph into a file. Specifically this method is used to save the contents of a Vamana 
@@ -110,11 +125,6 @@ public:
    * @return true if the graph was loaded successfully, false otherwise
   */
   bool loadGraph(const std::string& filename);
-
-  //####################################################################
-  //this is the new filtered medoid, i will brief in later time
-  //####################################################################
-  map<int, BaseDataVector<float>> FilteredMedoid(const Graph<vamana_t>& Graph, int threshold);
 
   /**
    * @brief Finds the medoid node in the graph using a sample of nodes.

--- a/include/distance.h
+++ b/include/distance.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include "DataVector.h"
 
+
 /**
  * @brief Comparator structure for ordering elements by Euclidean distance.
  * 
@@ -17,13 +18,16 @@ template <typename base_t, typename query_t>
 struct EuclideanDistanceOrder {
 
   query_t xq; // Target vector for distance comparisons
+  double** distances;
+  bool useCashe;
 
   /**
    * @brief Constructs a new EuclideanDistanceOrder object with a target vector.
    * 
    * @param target The target vector for distance comparisons.
    */
-  EuclideanDistanceOrder(const query_t& target) : xq(target) {}
+  EuclideanDistanceOrder(const query_t& target, double** distanceMatrix, const bool useCashe_) 
+    : xq(target), distances(distanceMatrix), useCashe(useCashe_) {}
 
   /**
    * @brief Comparison operator for ordering elements by Euclidean distance.

--- a/src/DataReaders/read_vectors.cpp
+++ b/src/DataReaders/read_vectors.cpp
@@ -3,6 +3,8 @@
 #include <vector>
 #include "../../include/DataVector.h"
 #include "../../include/read_data.h"
+#include "../../include/graphics.h"
+
 
 using namespace std;
 
@@ -162,7 +164,8 @@ std::vector<BaseDataVector<float>> ReadFilteredBaseVectorFile(const string& file
     vector<BaseDataVector<float>> dataVectors;
     dataVectors.reserve(num_vectors);
 
-    for (unsigned int i = 0; i < num_vectors; ++i) {
+    withProgress(0, num_vectors, "Reading base vectors", [&](int i) {
+
         float C, T;
         file.read(reinterpret_cast<char*>(&C), sizeof(C));
         file.read(reinterpret_cast<char*>(&T), sizeof(T));
@@ -176,7 +179,8 @@ std::vector<BaseDataVector<float>> ReadFilteredBaseVectorFile(const string& file
         }
 
         dataVectors.push_back(dataVector);
-    }
+        
+    });
 
     file.close();
     return dataVectors;

--- a/src/Geometry/distance_functions.cpp
+++ b/src/Geometry/distance_functions.cpp
@@ -17,8 +17,15 @@ using namespace std;
  */
 template <typename base_t, typename query_t> bool EuclideanDistanceOrder<base_t, query_t>::operator()(const base_t& a, const base_t& b) {
 
-    double distanceA = euclideanDistance(a, xq);
-    double distanceB = euclideanDistance(b, xq);
+    double distanceA, distanceB;
+
+    if (!useCashe) {
+        distanceA = euclideanDistance(a, xq);
+        distanceB = euclideanDistance(b, xq);
+    } else {
+        distanceA = distances[a.getIndex()][xq.getIndex()];
+        distanceB = distances[b.getIndex()][xq.getIndex()];
+    }
 
     // Primary comparison by distance
     if (distanceA != distanceB) {

--- a/src/VIA/Algorithms/RobustPrune.cpp
+++ b/src/VIA/Algorithms/RobustPrune.cpp
@@ -50,7 +50,7 @@ static set_t getSetItemAtIndex(const unsigned int& index, const std::set<set_t>&
  * 5. Stops when the number of neighbors of `p_node` reaches `R` or `V` is empty.
  */
 template <typename graph_t>
-void RobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R) {
+void RobustPrune(VamanaIndex<graph_t>& index, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R) {
     
   // Get the data of the node p_node
   graph_t p = p_node.getData();
@@ -70,11 +70,13 @@ void RobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t
 
     // Find the closest neighbor to p_node in V
     graph_t p_star = getSetItemAtIndex(0, V);
-    float p_star_distance = euclideanDistance(p, p_star);
+    // float p_star_distance = euclideanDistance(p, p_star);
+    float p_star_distance = index.getDistanceMatrix()[p.getIndex()][p_star.getIndex()];
 
     // Update p_star if a closer neighbor is found
     for (auto p_tone : V) {
-      float currentDistance = euclideanDistance(p, p_tone);
+      // float currentDistance = euclideanDistance(p, p_tone);
+      float currentDistance = index.getDistanceMatrix()[p.getIndex()][p_tone.getIndex()];
       
       if (currentDistance < p_star_distance) {
         p_star_distance = currentDistance;
@@ -94,7 +96,10 @@ void RobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t
     std::set<graph_t> V_copy = V;
     for (auto p_tone : V_copy) {
       // Remove neighbors that are too far from p_star based on alpha and euclideanDistance
-      if ((alpha * euclideanDistance(p_star, p_tone)) <= euclideanDistance(p, p_tone)) {
+      // if ((alpha * euclideanDistance(p_star, p_tone)) <= euclideanDistance(p, p_tone)) {
+      //   V.erase(p_tone);
+      // }
+      if ((alpha * index.getDistanceMatrix()[p_star.getIndex()][p_tone.getIndex()]) <= index.getDistanceMatrix()[p.getIndex()][p_tone.getIndex()]) {
         V.erase(p_tone);
       }
     }
@@ -102,7 +107,7 @@ void RobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t
 }
 
 template <typename graph_t>
-void FilteredRobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R) {
+void FilteredRobustPrune(FilteredVamanaIndex<graph_t>& index, GraphNode<graph_t>& p_node, std::set<graph_t>& V, float alpha, int R) {
   
   // Get the data of the node p_node
   graph_t p = p_node.getData();
@@ -124,11 +129,13 @@ void FilteredRobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set
 
     // Find the closest neighbor to p_node in V
     graph_t p_star = getSetItemAtIndex(0, V);
-    float p_star_distance = euclideanDistance(p, p_star);
+    // float p_star_distance = euclideanDistance(p, p_star);
+    float p_star_distance = index.getDistanceMatrix()[p.getIndex()][p_star.getIndex()];
 
     // Update p_star if a closer neighbor is found
     for (auto p_tone : V) {
-      float currentDistance = euclideanDistance(p, p_tone);
+      // float currentDistance = euclideanDistance(p, p_tone);
+      float currentDistance = index.getDistanceMatrix()[p.getIndex()][p_tone.getIndex()];
       if (currentDistance < p_star_distance) {
         p_star_distance = currentDistance;
         p_star = p_tone;
@@ -160,7 +167,10 @@ void FilteredRobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set
       }
 
       // Remove nodes that do NOT satisfy the filtering condition
-      if ((alpha * euclideanDistance(p_star, p_tone)) <= euclideanDistance(p, p_tone)) {
+      // if ((alpha * euclideanDistance(p_star, p_tone)) <= euclideanDistance(p, p_tone)) {
+      //   V.erase(p_tone);
+      // }
+      if ((alpha * index.getDistanceMatrix()[p_star.getIndex()][p_tone.getIndex()]) <= index.getDistanceMatrix()[p.getIndex()][p_tone.getIndex()]) {
         V.erase(p_tone);
       }
 
@@ -169,7 +179,7 @@ void FilteredRobustPrune(Graph<graph_t>& G, GraphNode<graph_t>& p_node, std::set
 }
 
 template void RobustPrune<DataVector<float>>(
-  Graph<DataVector<float>>& G, 
+  VamanaIndex<DataVector<float>>& index, 
   GraphNode<DataVector<float>>& p_node, 
   std::set<DataVector<float>>& V, 
   float alpha, 
@@ -177,7 +187,7 @@ template void RobustPrune<DataVector<float>>(
 );
 
 template void RobustPrune<BaseDataVector<float>>(
-  Graph<BaseDataVector<float>>& G, 
+  VamanaIndex<BaseDataVector<float>>& index, 
   GraphNode<BaseDataVector<float>>& p_node, 
   std::set<BaseDataVector<float>>& V, 
   float alpha, 
@@ -185,7 +195,7 @@ template void RobustPrune<BaseDataVector<float>>(
 );
 
 template void FilteredRobustPrune<BaseDataVector<float>>(
-  Graph<BaseDataVector<float>>& G, 
+  FilteredVamanaIndex<BaseDataVector<float>>& index, 
   GraphNode<BaseDataVector<float>>& p_node, 
   std::set<BaseDataVector<float>>& V, 
   float alpha, 

--- a/src/VIA/Algorithms/StichedVamanaIndex.cpp
+++ b/src/VIA/Algorithms/StichedVamanaIndex.cpp
@@ -24,6 +24,11 @@ void StichedVamanaIndex<vamana_t>::createGraph(
   // Initialize graph memory
   unsigned int n = P.size();
   this->P = P;
+  this->distanceMatrix = new double*[n];
+  for (unsigned int i = 0; i < n; i++) {
+    this->distanceMatrix[i] = new double[n];
+  }
+  this->computeDistances();
 
   // Initialize G = (V, E) to an empty graph
   this->G.setNodesCount(n);
@@ -63,7 +68,7 @@ void StichedVamanaIndex<vamana_t>::createGraph(
 
     // Initialize the sub-index for the current filter and create its graph
     VamanaIndex<vamana_t> subIndex;
-    subIndex.createGraph(Pf[filter], alpha, R_small, L_small, false);
+    subIndex.createGraph(Pf[filter], alpha, R_small, L_small, false, this->distanceMatrix);
 
     for (unsigned int i = 0; i < subIndex.getGraph().getNodesCount(); i++) {
       
@@ -89,9 +94,15 @@ void StichedVamanaIndex<vamana_t>::createGraph(
     std::set<vamana_t> neighbors = currentNode->getNeighborsSet();
 
     // Run Filtered Robust Prune for the current node and its neighbors
-    FilteredRobustPrune(this->G, *currentNode, neighbors, alpha, R_stiched);
+    FilteredRobustPrune(*this, *currentNode, neighbors, alpha, R_stiched);
 
   }
+
+  // Free up the memory allocated for the distance matrix
+  for (unsigned int i = 0; i < n; i++) {
+    delete[] this->distanceMatrix[i];
+  }
+  delete[] this->distanceMatrix;
 
 }
 


### PR DESCRIPTION
Added functionality to compute all the distances at the beginning of the search process so later the algorithms can use the stored distances in O(1) time instead of computing them again. This currently reduces the time required for the algorithms to run and specifically the Simple VIA took around 13 minutes to run, without the improvement, and now with the above addition to the code it takes around 8 minutes to execute.